### PR TITLE
Aggiunto metodo getAllErrors(), restituisce tutti gli errori sotto forma di array

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,23 @@ $feValidator->assertValidXml('<xml ...>');
 //      SlamFatturaElettronica\Exception\InvalidXsdStructureComplianceException
 ```
 
+## Elencare tutti gli errori rilevati
+
+```php
+use SlamFatturaElettronica\Validator;
+
+$feValidator = new Validator();
+$feValidator->getAllErrors('<xml ...>');
+
+// Restituisce un array contentente gli errori rilevati. Se non ci sono errori l'array sarà vuoto:
+// Array
+// (
+//     [0] => DOMDocument::schemaValidateSource(): Element 'IdPaese': [facet 'pattern'] The value '' is not accepted by the pattern '[A-Z]{2}'.
+//     [1] => DOMDocument::schemaValidateSource(): Element 'Numero': [facet 'pattern'] The value '' is not accepted by the pattern '(\p{IsBasicLatin}{1,20})'.
+// )
+
+```
+
 ### Notifiche
 
 ```php

--- a/lib/Validator.php
+++ b/lib/Validator.php
@@ -63,19 +63,17 @@ final class Validator implements ValidatorInterface
         throw new Exception\InvalidXsdStructureComplianceException($xsdErrorArguments[1], $xsdErrorArguments[0], $xsdErrorArguments[0], $xsdErrorArguments[2], $xsdErrorArguments[3]);
     }
 
-    /**
-     * @return array <int, string> Array of errors. An empty array will be returned if there are no errors
-     */
+    /** @return array <int, string> Array of errors. An empty array will be returned if there are no errors */
     public function getAllErrors(string $xml, string $type = self::XSD_FATTURA_ORDINARIA_LATEST): array
     {
-        $dom = new DOMDocument();
+        $dom          = new DOMDocument();
         $dom->recover = true;
-        $dom->loadXML($xml, LIBXML_NOERROR);
+        $dom->loadXML($xml, \LIBXML_NOERROR);
         $xsd = $this->getXsd($type);
 
         $errors = [];
 
-        set_error_handler(static function (int $errno, string $errstr = '', string $errfile = '', int $errline = 0) use (&$errors): bool {
+        \set_error_handler(static function (int $errno, string $errstr = '', string $errfile = '', int $errline = 0) use (& $errors): bool {
             $errors[] = $errstr;
 
             return true;
@@ -83,9 +81,9 @@ final class Validator implements ValidatorInterface
 
         $result = $dom->schemaValidateSource($xsd);
 
-        restore_error_handler();
+        \restore_error_handler();
 
-        if (!$result && count($errors) > 0) {
+        if (! $result && \count($errors) > 0) {
             return $errors;
         }
 

--- a/lib/Validator.php
+++ b/lib/Validator.php
@@ -79,6 +79,22 @@ final class Validator implements ValidatorInterface
             return true;
         });
 
+        $dom->loadXML($xml);
+
+        \restore_error_handler();
+
+        if (\count($errors) > 0) {
+            return $errors;
+        }
+
+        $errors = [];
+
+        \set_error_handler(static function (int $errno, string $errstr = '', string $errfile = '', int $errline = 0) use (& $errors): bool {
+            $errors[] = $errstr;
+
+            return true;
+        });
+
         $result = $dom->schemaValidateSource($xsd);
 
         \restore_error_handler();

--- a/lib/Validator.php
+++ b/lib/Validator.php
@@ -64,7 +64,7 @@ final class Validator implements ValidatorInterface
     }
 
     /**
-     * @return array <string, string> Array of errors. An empty array will be returned if there are no errors
+     * @return array <int, string> Array of errors. An empty array will be returned if there are no errors
      */
     public function getAllErrors(string $xml, string $type = self::XSD_FATTURA_ORDINARIA_LATEST): array
     {
@@ -85,7 +85,7 @@ final class Validator implements ValidatorInterface
 
         restore_error_handler();
 
-        if (!$result && !empty($errors)) {
+        if (!$result && count($errors) > 0) {
             return $errors;
         }
 

--- a/tests/TestAsset/invalid_xsd_content.xml
+++ b/tests/TestAsset/invalid_xsd_content.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<p:FatturaElettronica versione="FPA12" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" 
+xmlns:p="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2 http://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.2/Schema_del_file_xml_FatturaPA_versione_1.2.xsd">
+  <FatturaElettronicaHeader>
+    <DatiTrasmissione>
+      <IdTrasmittente>
+        <IdPaese>ITALIA</IdPaese>
+        <IdCodice>01234567890</IdCodice>
+      </IdTrasmittente>
+      <ProgressivoInvio>00001</ProgressivoInvio>
+      <FormatoTrasmissione>FPR12</FormatoTrasmissione>
+      <CodiceDestinatario>ABC1234</CodiceDestinatario>
+      <ContattiTrasmittente/>
+    </DatiTrasmissione>
+    <CedentePrestatore>
+      <DatiAnagrafici>
+        <IdFiscaleIVA>
+          <IdPaese>IT</IdPaese>
+          <IdCodice>01234567890</IdCodice>
+        </IdFiscaleIVA>
+        <Anagrafica>
+          <Denominazione>SOCIETA' ALPHA SRL</Denominazione>
+        </Anagrafica>
+        <RegimeFiscale>RF19</RegimeFiscale>
+      </DatiAnagrafici>
+      <Sede>
+        <Indirizzo>VIALE ROMA 543</Indirizzo>
+        <CAP>07100</CAP>
+        <Comune>SASSARI</Comune>
+        <Provincia>SS</Provincia>
+        <Nazione>IT</Nazione>
+      </Sede>
+    </CedentePrestatore>
+    <CessionarioCommittente>
+      <DatiAnagrafici>
+        <CodiceFiscale>09876543210</CodiceFiscale>
+        <Anagrafica>
+          <Denominazione>DITTA BETA</Denominazione>
+        </Anagrafica>
+      </DatiAnagrafici>
+      <Sede>
+        <Indirizzo>VIA TORINO 38-B</Indirizzo>
+        <CAP>00145</CAP>
+        <Comune>ROMA</Comune>
+        <Provincia>RM</Provincia>
+        <Nazione>IT</Nazione>
+      </Sede>
+    </CessionarioCommittente>
+  </FatturaElettronicaHeader>
+  <FatturaElettronicaBody>
+    <DatiGenerali>
+      <DatiGeneraliDocumento>
+        <TipoDocumento>TD01</TipoDocumento>
+        <Divisa>EUR</Divisa>
+        <Data>2014-12-18</Data>
+        <Numero>123</Numero>
+        <Causale>LA FATTURA FA RIFERIMENTO AD UNA OPERAZIONE AAAA BBBBBBBBBBBBBBBBBB CCC DDDDDDDDDDDDDDD E FFFFFFFFFFFFFFFFFFFF GGGGGGGGGG HHHHHHH II LLLLLLLLLLLLLLLLL MMM NNNNN OO PPPPPPPPPPP QQQQ RRRR SSSSSSSSSSSSSS</Causale>
+        <Causale>SEGUE DESCRIZIONE CAUSALE NEL CASO IN CUI NON SIANO STATI SUFFICIENTI 200 CARATTERI AAAAAAAAAAA BBBBBBBBBBBBBBBBB</Causale>
+      </DatiGeneraliDocumento>
+      <DatiOrdineAcquisto>
+        <RiferimentoNumeroLinea>1</RiferimentoNumeroLinea>
+        <IdDocumento>66685</IdDocumento>
+        <NumItem>1</NumItem>
+      </DatiOrdineAcquisto>
+      <DatiContratto>
+	    <RiferimentoNumeroLinea>1</RiferimentoNumeroLinea>
+	    <IdDocumento>123</IdDocumento>
+	    <Data>2012-09-01</Data>
+	    <NumItem>5</NumItem>
+	    <CodiceCUP>123abc</CodiceCUP>
+	    <CodiceCIG>456def</CodiceCIG>
+      </DatiContratto>
+      <DatiTrasporto>
+	    <DatiAnagraficiVettore>				
+	      <IdFiscaleIVA>
+	        <IdPaese>IT</IdPaese>
+	        <IdCodice>24681012141</IdCodice>
+	      </IdFiscaleIVA>
+    	  <Anagrafica>
+	        <Denominazione>Trasporto spa</Denominazione>
+	      </Anagrafica>
+	    </DatiAnagraficiVettore>
+	    <DataOraConsegna>2012-10-22T16:46:12.000+02:00</DataOraConsegna>
+      </DatiTrasporto>
+    </DatiGenerali>
+    <DatiBeniServizi>
+      <DettaglioLinee>
+        <NumeroLinea>1</NumeroLinea>
+        <Descrizione>DESCRIZIONE DELLA FORNITURA</Descrizione>
+        <Quantita>5.00</Quantita>
+        <PrezzoUnitario>1.00</PrezzoUnitario>
+        <PrezzoTotale>5.00</PrezzoTotale>
+        <AliquotaIVA>22.00</AliquotaIVA>
+      </DettaglioLinee>
+      <DatiRiepilogo>
+        <AliquotaIVA>22.00</AliquotaIVA>
+        <ImponibileImporto>5</ImponibileImporto>
+        <Imposta>1.10</Imposta>
+        <EsigibilitaIVA>I</EsigibilitaIVA>
+      </DatiRiepilogo>
+    </DatiBeniServizi>
+    <DatiPagamento>
+      <CondizioniPagamento>TP01</CondizioniPagamento>
+      <DettaglioPagamento>
+        <ModalitaPagamento>MP01</ModalitaPagamento>
+        <DataScadenzaPagamento>2030</DataScadenzaPagamento>
+        <ImportoPagamento>6.10</ImportoPagamento>
+      </DettaglioPagamento>
+    </DatiPagamento>
+  </FatturaElettronicaBody>
+</p:FatturaElettronica>

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -94,7 +94,15 @@ final class ValidatorTest extends TestCase
         return $content;
     }
 
-    public function testGetAllErrorsNotEmpty(): void
+    public function testGetAllErrorsXmlNotEmpty(): void
+    {
+        $xml = $this->getXmlContent('invalid_xml_tags.xml');
+
+        $errors = (new Validator())->getAllErrors($xml);
+        self::assertNotEmpty($errors);
+    }
+
+    public function testGetAllErrorsXsdNotEmpty(): void
     {
         $xml = $this->getXmlContent('invalid_xsd_content.xml');
 

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -38,7 +38,6 @@ final class ValidatorTest extends TestCase
             ['ok_ITHVQWPH73P42H501Y_00023.xml'],
             ['ok_ITHVQWPH73P42H501Y_X0024.xml'],
             ['ok_bug_attribute_with_space.xml'],
-            ['ok_bug_attribute_with_space.xml'],
         ];
     }
 

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -38,6 +38,7 @@ final class ValidatorTest extends TestCase
             ['ok_ITHVQWPH73P42H501Y_00023.xml'],
             ['ok_ITHVQWPH73P42H501Y_X0024.xml'],
             ['ok_bug_attribute_with_space.xml'],
+            ['ok_bug_attribute_with_space.xml'],
         ];
     }
 
@@ -92,5 +93,21 @@ final class ValidatorTest extends TestCase
         self::assertNotFalse($content);
 
         return $content;
+    }
+
+    public function testGetAllErrorsNotEmpty(): void
+    {
+        $xml = $this->getXmlContent('invalid_xsd_content.xml');
+
+        $errors = (new Validator())->getAllErrors($xml);
+        self::assertNotEmpty($errors);
+    }
+
+    public function testGetAllErrorsIsEmpty(): void
+    {
+        $xml = $this->getXmlContent('ok_IT01234567890_FPR01.xml');
+
+        $errors = (new Validator())->getAllErrors($xml);
+        self::assertEmpty($errors);
     }
 }


### PR DESCRIPTION
Per alcuni utilizzi può essere utile ottenere un array contenente tutti gli errori, invece di un'eccezione al primo errore rilevato. Questa pull request aggiunge questa funzionalità. Ho aggiornato il file README.md con un esempio di utilizzo.